### PR TITLE
Allow building on linux via Makefile

### DIFF
--- a/Galaxy.cpp
+++ b/Galaxy.cpp
@@ -4,7 +4,6 @@
 #include <stdexcept>
 #include <cmath>
 #include <iostream>
-#include <execution>
 #include <algorithm>
 
 #include "Helper.hpp"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+
+CPPFILES=CumulativeDistributionFunction.cpp Galaxy.cpp GalaxyWnd.cpp Helper.cpp main.cpp SDLWnd.cpp TextBuffer.cpp
+OBJFILES=$(CPPFILES:.cpp=.o)
+OUT=main
+PKG_CONFIG?=pkg-config
+SDLLIBS:=$(shell $(PKG_CONFIG) sdl2 --libs)
+SDLCFLAGS:=$(shell $(PKG_CONFIG) sdl2 --cflags)
+GLEWLIBS:=$(shell $(PKG_CONFIG) --libs-only-l glew)
+GLEWCFLAGS:=$(shell $(PKG_CONFIG) --cflags glew)
+DEBUG=-g
+CFLAGS=${DEBUG} -Wall -Wextra --pedantic -std=c++11 -Iinclude -I/usr/include/SDL2 ${GLEWCFLAGS} ${SDLCFLAGS}
+LIBS=${SDLLIBS} ${GLEWLIBS} -lSDL2_ttf
+
+COMPILE=g++ ${CFLAGS}
+
+
+$(OUT):	$(OBJFILES)
+	$(COMPILE) -o $@ $^ ${LIBS}
+
+%.o:	%.cpp
+	$(COMPILE) -c -o $@ $^
+
+clean:
+	rm -f ${OBJFILES} main
+

--- a/include/SDLWnd.hpp
+++ b/include/SDLWnd.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <glm/glm.hpp>
 
 #include <SDL.h>

--- a/include/TextBuffer.hpp
+++ b/include/TextBuffer.hpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <stdexcept>
 
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <glm/glm.hpp>
 
 #include <SDL_ttf.h>

--- a/include/VertexBufferBase.hpp
+++ b/include/VertexBufferBase.hpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <cstdint>
 
-#include <gl/glew.h>
+#include <GL/glew.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 


### PR DESCRIPTION
This adds a small Makefile and fixes a few minor things to make this program compile easily on linux.

1. Star.cpp appears to be unused.
2. #include execution in Galaxy.cpp appears to be unneeded (or am I wrong about that?)
3. linux filesystems are case sensitive generally, so the correct case must be used when including OpenGL headers.
4. Added a small Makefile which compiles successfully and produces an executable.

However, the executable it produces does not work for me, it segfaults almost immediately (as described in #4 )  But maybe allowing the program to be easily built on linux will enable someone else to debug this problem more easily.
