### PR TITLE
Remove unused VBO member variable from TextBuffer

### DIFF
--- a/TextBuffer.cpp
+++ b/TextBuffer.cpp
@@ -12,7 +12,6 @@ TextBuffer::TextBuffer()
 	, _pSmallFont(nullptr)
 	, _pFont(nullptr)
 	, _pFontCaption(nullptr)
-	, _vbo(0)
 	, _updating(false)
 	, _shaderProgram(0)
 {}
@@ -99,8 +98,6 @@ void TextBuffer::Initialize()
 	if (_pFontCaption == nullptr)
 		throw std::runtime_error(TTF_GetError());
 
-	glGenBuffers(1, &_vbo);
-
 	const char* srcVertex = GetVertexShaderSource();
 	GLuint vertexShader = CreateShader(GL_VERTEX_SHADER, &srcVertex);
 
@@ -163,9 +160,6 @@ void TextBuffer::Clear()
 	}
 
 	_textureData.clear();
-
-	if (_vbo != 0)
-		glDeleteBuffers(1, &_vbo);
 }
 
 void TextBuffer::Draw(int width, int height, glm::mat4& matView, glm::mat4& matProjection)

--- a/include/TextBuffer.hpp
+++ b/include/TextBuffer.hpp
@@ -47,8 +47,6 @@ private:
 		attTexturePosition = 1
 	};
 
-	GLuint _vbo;
-
 	bool _updating;
 
 	std::vector<TextureData> _textureData;


### PR DESCRIPTION
## Summary
Removed the unused `_vbo` (Vertex Buffer Object) member variable and its associated initialization and cleanup code from the TextBuffer class.

## Key Changes
- Removed `_vbo` member variable declaration from `TextBuffer.hpp`
- Removed `_vbo` initialization from the constructor member initializer list
- Removed `glGenBuffers()` call from `Initialize()` method
- Removed `glDeleteBuffers()` cleanup code from `Clear()` method

## Details
The `_vbo` member variable was declared but never actually used in the TextBuffer implementation. This change eliminates dead code by removing:
- The unused member variable
- The OpenGL buffer generation that served no purpose
- The corresponding cleanup logic

This simplifies the class and reduces unnecessary OpenGL API calls without affecting functionality.

https://claude.ai/code/session_01PcJMVEK2xNhTJJUni67y3b